### PR TITLE
Use paren syntax for function declaration and application

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ Hiss is a hobby functional programming language.
 A simple Hiss program, [collatz.hiss](samples/collatz.hiss):
 ```
 // computes k mod n
-let mod n k = if k < n
+let mod(n,k) = if k < n
               then k
-              else mod n (k-n)
+              else mod (n,k-n)
 in
 // partial function application
-let mod2 = mod 2 in
+let mod2 = mod(2) in
 // computes total stopping time of n
-let collatz n steps = if n == 1
-                      then steps
-                      else if mod2 n == 0
-                           then collatz (n/2) (steps + 1)
-                           else collatz (3*n + 1) (steps + 1)
+let collatz(n,steps) = if n == 1
+                       then steps
+                       else if mod2(n) == 0
+                            then collatz(n/2, steps + 1)
+                            else collatz (3*n + 1, steps + 1)
 in
-    collatz 27 0 // should output 111
+    collatz(27,0) // should output 111
 ```
 (syntax is subject to change)
 ## Commands

--- a/samples/collatz.hiss
+++ b/samples/collatz.hiss
@@ -1,15 +1,15 @@
 // computes k mod n
-let mod n k = if k < n
+let mod(n,k) = if k < n
               then k
-              else mod n (k-n)
+              else mod (n,k-n)
 in
 // partial function application
-let mod2 = mod 2 in
+let mod2 = mod(2) in
 // computes total stopping time of n
-let collatz n steps = if n == 1
-                      then steps
-                      else if mod2 n == 0
-                           then collatz (n/2) (steps + 1)
-                           else collatz (3*n + 1) (steps + 1)
+let collatz(n,steps) = if n == 1
+                       then steps
+                       else if mod2(n) == 0
+                            then collatz(n/2, steps + 1)
+                            else collatz (3*n + 1, steps + 1)
 in
-    collatz 27 0 // should output 111
+    collatz(27,0) // should output 111

--- a/samples/fib.hiss
+++ b/samples/fib.hiss
@@ -1,6 +1,6 @@
 // computes nth fibonacci number recursively
-let fib n = if n <= 1 
-            then 1
-            else fib (n-1) + fib (n-2)
+let fib(n) = if n <= 1 
+             then 1
+             else fib(n-1) + fib(n-2)
 in
-    fib 13 // should output 377
+    fib(13) // should output 377

--- a/src/Interpreter/TreeWalker.hs
+++ b/src/Interpreter/TreeWalker.hs
@@ -9,7 +9,7 @@ import Data.Map.Strict qualified as Map (empty, fromList, insert, lookup, restri
 import Data.Set ((\\))
 import Data.Set qualified as Set (fromList)
 import Error (HissError (RuntimeError))
-import Syntax.AST (BinOp (..), Exp (..), FunApp (..), LetBinding (..), Name (..), UnaryOp (..), getIdent, stripAnns)
+import Syntax.AST (BinOp (..), Exp (..), FunApp (..), Binding (..), Name (..), UnaryOp (..), getIdent, stripAnns)
 import Semantic.Names (collectNames)
 
 data HissValue
@@ -63,10 +63,10 @@ eval' (EVar () n) = do
   case Map.lookup n env of
     Just val -> return val
     Nothing -> throwError (RuntimeError $ "Name error: name " <> getIdent n <> " undefined in current environment")
-eval' (ELetIn () lb valExp inExp) = do
-  case lb of
-    -- variable binding
-    LetBinding () n [] -> do
+eval' (ELetIn () b valExp inExp) = do
+  case b of
+    -- val binding
+    ValBinding () n -> do
       val <- eval' valExp -- compute value
       env <- insertBinding n val -- bind n to val
 
@@ -77,7 +77,7 @@ eval' (ELetIn () lb valExp inExp) = do
       put env
       return inVal
     -- function binding
-    LetBinding () n args -> do
+    FuncBinding () n args -> do
       -- names referenced inside the closure (minus the function arguments)
       let capturedNames = collectNames valExp \\ Set.fromList args
 

--- a/src/Syntax/Lexer.x
+++ b/src/Syntax/Lexer.x
@@ -25,6 +25,7 @@ tokens :-
 -- tokens
 <0>       \(                         { mkLexeme LParen }
 <0>       \)                         { mkLexeme RParen }
+<0>       ","                        { mkLexeme Comma }
 <0>       "+"                        { mkLexeme Plus }
 <0>       "-"                        { mkLexeme Minus }
 <0>       "*"                        { mkLexeme Star }
@@ -54,6 +55,7 @@ tokens :-
 data Token = EOF
            | LParen
            | RParen
+           | Comma
            | Plus
            | Minus
            | Star

--- a/src/Syntax/Parser.y
+++ b/src/Syntax/Parser.y
@@ -25,6 +25,7 @@ import Data.Maybe (fromJust)
 %token
     '('                    { Lexeme{ tok = T.LParen } }
     ')'                    { Lexeme{ tok = T.RParen } }
+    ','                    { Lexeme{ tok = T.Comma } }
     '+'                    { Lexeme{ tok = T.Plus } }
     '-'                    { Lexeme{ tok = T.Minus } }
     '*'                    { Lexeme{ tok = T.Star } }

--- a/src/Syntax/Parser.y
+++ b/src/Syntax/Parser.y
@@ -2,7 +2,7 @@
 module Syntax.Parser ( parseHiss ) where
 import Syntax.Lexer ( Lexeme(..), Range(..), AlexPosn(..), Alex, mergeRange, alexError, alexGetInput, alexMonadScan )
 import qualified Syntax.Lexer as T (Token (..))
-import Syntax.AST( Exp(..), Name(..), UnaryOp(..), BinOp(..), LetBinding(..), FunApp(..), getAnn )
+import Syntax.AST( Exp(..), Name(..), UnaryOp(..), BinOp(..), Binding(..), FunApp(..), getAnn )
 import Data.Maybe (fromJust)
 }
 
@@ -57,7 +57,7 @@ import Data.Maybe (fromJust)
 exp  : atom                                { $1 }
      | '!' atom                            { mkUnaryOpExp $1 $2 }
      | funApp                              { mkFunAppExp $1 }
-     | 'let' letBinding '=' exp 'in' exp   { mkLetInExp $2 $4 $6}
+     | 'let' binding '=' exp 'in' exp      { mkLetInExp $2 $4 $6}
      | 'if' exp 'then' exp 'else' exp      { mkIfExp $2 $4 $6 }
      | exp '*' exp                         { mkBinOpExp $1 Mult $3 }
      | exp '/' exp                         { mkBinOpExp $1 Div $3 }
@@ -79,9 +79,13 @@ atom : 'true'                              { mkBoolExp $1 }
      | ident                               { mkVarExp $1 }
      | '(' exp ')'                         { mkParenExp $1 $2 $3 }
 
--- a let binding is simply one or more names
-letBinding : ident                         { mkLetBinding $1 }
-           | letBinding ident              { letBindingAppendArg $1 $2 }
+-- either a value binding (just a name) or a func binding (a func name and zero or more arg names)
+binding : ident                            { mkValBinding $1 }
+        | ident '(' funBindingArgs ')'     { mkFuncBinding $1 $3 }
+
+funBindingArgs : {- empty -}               { [] :: [Lexeme] }
+               | ident                     { [$1] }
+               | funBindingArgs ',' ident  { $3 : $1 }
 
 funApp : atom '(' funArgs ')'              { mkFunApp $1 $3 }
 
@@ -94,7 +98,7 @@ mkUnaryOpExp :: Lexeme -> Exp Range -> Exp Range
 mkUnaryOpExp Lexeme{ tok=T.Not, rng=r1 } e1 = EUnaryOp r1 Not e1
     where r = r1 `mergeRange` (getAnn e1)
 
-mkLetInExp :: LetBinding Range -> Exp Range -> Exp Range -> Exp Range
+mkLetInExp :: Binding Range -> Exp Range -> Exp Range -> Exp Range
 mkLetInExp binding e1 e2 = ELetIn r binding e1 e2
     where r = (getAnn binding) `mergeRange` (getAnn e1) `mergeRange` (getAnn e2) 
 
@@ -126,22 +130,26 @@ mkParenExp :: Lexeme -> Exp Range -> Lexeme -> Exp Range
 mkParenExp Lexeme { rng = lRng } e1 Lexeme { rng = rRng } = EParen r (e1)
     where r = lRng `mergeRange` rRng
 
--- Creates a let binding with a name and no arguments.
-mkLetBinding :: Lexeme -> LetBinding Range
-mkLetBinding Lexeme { tok=T.Ident, val=name, rng=r } = LetBinding r (Name r name) []
-mkLetBinding _ = error "Compiler bug: mkLetBinding called with a non-identifier lexeme"
+-- Creates a value binding
+mkValBinding :: Lexeme -> Binding Range
+mkValBinding Lexeme { tok = T.Ident, val=name, rng=r } = ValBinding r (Name r name)
+mkLetBinding _ = error "Compiler bug: mkValBinding called with a non-identifier lexeme"
 
--- Appends an argument to an existing let binding.
-letBindingAppendArg :: LetBinding Range -> Lexeme -> LetBinding Range
-letBindingAppendArg (LetBinding r1 name names) Lexeme { tok=T.Ident, val=newName, rng=r2 }
-    = LetBinding r' name (names ++ [ Name r2 newName ])
-    where r' = r1 `mergeRange` r2
-letBindingAppendArg _ _ = error "Compiler bug: letBindingAppendArg called with a non-identifier lexeme"
+-- Converts an identifier to a Name.
+mkName :: Lexeme -> Name Range
+mkName Lexeme { tok=T.Ident, val=name, rng=r } = Name r name
+mkName _ = error "Compiler bug: mkName called with a non-identifier lexeme"
+
+-- Creates a function binding
+mkFuncBinding :: Lexeme -> [Lexeme] -> Binding Range
+mkFuncBinding Lexeme { tok = T.Ident, val=name, rng=r1 } argLexemes = FuncBinding r' (Name r1 name) (reverse args)
+    where args = map mkName argLexemes
+          r' = r1 `mergeRange` (foldl1 mergeRange (map getAnn args))
 
 -- Creates a function application with a function name and one argument
 mkFunApp :: Exp Range -> [Exp Range] -> FunApp Range
-mkFunApp e1 es = FunApp r e1 es
-    where r = (getAnn e1) {-`mergeRange` (foldr1 mergeRange (map getAnn es))-}
+mkFunApp e1 es = FunApp r e1 (reverse es)
+    where r = (getAnn e1) `mergeRange` (foldl1 mergeRange (map getAnn es))
 
 parseError :: Lexeme -> Alex a
 parseError _ = do

--- a/test/Semantic/NamesSpec.hs
+++ b/test/Semantic/NamesSpec.hs
@@ -13,13 +13,13 @@ exp1 :: Exp Range
 exp1 = fromRight $ parseString "x + y - z"
 
 exp2 :: Exp Range
-exp2 = fromRight $ parseString "let f x y = z in f 0"
+exp2 = fromRight $ parseString "let f(x,y) = z in f(0)"
 
 exp3 :: Exp Range
-exp3 = fromRight $ parseString "let f x y = x in f 0 0"
+exp3 = fromRight $ parseString "let f(x,y) = x in f(0,0)"
 
 exp4 :: Exp Range
-exp4 = fromRight $ parseString "let f x y = x in x"
+exp4 = fromRight $ parseString "let f(x,y) = x in x"
 
 spec :: Spec
 spec = do
@@ -32,4 +32,4 @@ spec = do
     it "allows use of declared names" $
       checkNames exp3 `shouldBe` Right exp3
     it "does not allow use of function arguments outside function" $
-      checkNames exp4 `shouldBe` Left (SemanticError "Use of undeclared name 'x' at line 1, column 18")
+      checkNames exp4 `shouldBe` Left (SemanticError "Use of undeclared name 'x' at line 1, column 19")

--- a/test/Syntax/ASTSpec.hs
+++ b/test/Syntax/ASTSpec.hs
@@ -1,6 +1,6 @@
 module Syntax.ASTSpec (spec) where
 
-import Syntax.AST (BinOp (Sub), Exp (..), FunApp (..), LetBinding (..), Name (..), getAnn, mapAnn)
+import Syntax.AST (BinOp (Sub), Binding (..), Exp (..), FunApp (..), Name (..), getAnn, mapAnn)
 import Test.Hspec (Spec, describe, it, shouldBe)
 
 spec :: Spec
@@ -15,7 +15,8 @@ spec = do
       getAnn (EIf "target" undefined undefined undefined) `shouldBe` "target"
       getAnn (EParen "target" undefined) `shouldBe` "target"
       getAnn (Name "target" undefined) `shouldBe` "target"
-      getAnn (LetBinding "target" undefined undefined) `shouldBe` "target"
+      getAnn (ValBinding "target" undefined) `shouldBe` "target"
+      getAnn (FuncBinding "target" undefined undefined) `shouldBe` "target"
       getAnn (FunApp "target" undefined undefined) `shouldBe` "target"
   describe "mapAnn" $
     it "maps annotations on a sample AST" $ -- uses integer annotations to test mapAnn
@@ -23,13 +24,13 @@ spec = do
         (* 2)
         ( ELetIn
             1
-            (LetBinding 2 (Name 3 "f") [Name 4 "x"])
+            (FuncBinding 2 (Name 3 "f") [Name 4 "x"])
             (EIf 5 (EVar 6 (Name 7 "x")) (EFunApp 8 (FunApp 9 (EVar 10 (Name 11 "f")) [EParen 12 (EBinOp 13 (EVar 14 (Name 15 "x")) Sub (EInt 16 1))])) (EInt 17 42))
             (EFunApp 18 (FunApp 19 (EVar 20 (Name 21 "f")) [EInt 22 4])) ::
             Exp Int
         )
         `shouldBe` ELetIn
           2
-          (LetBinding 4 (Name 6 "f") [Name 8 "x"])
+          (FuncBinding 4 (Name 6 "f") [Name 8 "x"])
           (EIf 10 (EVar 12 (Name 14 "x")) (EFunApp 16 (FunApp 18 (EVar 20 (Name 22 "f")) [EParen 24 (EBinOp 26 (EVar 28 (Name 30 "x")) Sub (EInt 32 1))])) (EInt 34 42))
           (EFunApp 36 (FunApp 38 (EVar 40 (Name 42 "f")) [EInt 44 4]))


### PR DESCRIPTION
## Context
Previously, we used Haskell-style syntax for function application. (E.g., `f x` = 'f applied to x')

This leaves an ambiguity for zero-arg functions: does an expression like `f` call `f` or just refer to it?
This distinction is unimportant (nonexistent) for lazy languages like Haskell, but currently the plan is to give Hiss eager evaluation semantics.

Parenthetical syntax allows you to differentiate easily: `f` refers to the function, `f()` invokes it.

## Changes
- Update lexer/parser to support C-style parenthetical function definition and application syntax
- Update AST and Semantic.Names to reflect these changes
- Update unit tests
- Update samples
