### PR TITLE
Give equality operators higher precedence than boolean operators

### DIFF
--- a/src/Syntax/Parser.y
+++ b/src/Syntax/Parser.y
@@ -18,8 +18,8 @@ import Data.Maybe (fromJust)
 -- associativity and operator precedence
 %right 'else'
 %right 'in' 
-%left '==' '!='
 %left '&&' '||'
+%left '==' '!='
 %nonassoc '<' '>' '<=' '>='
 %left '+' '-'
 %left '*' '/'

--- a/test/Syntax/ParserSpec.hs
+++ b/test/Syntax/ParserSpec.hs
@@ -18,18 +18,27 @@ spec = do
           (EInt () 4)
           (EBinOp () (EVar () (Name () "x")) Mult (EVar () (Name () "x")))
     it "respects operator precedence for comparisons and boolean operators" $
-      stripAnns (fromRight $ parseExpression "a < b && c >= d || e <= f")
+      stripAnns (fromRight $ parseExpression "a < b && c >= d || e <= f && g == h")
         `shouldBe` EBinOp
           ()
           ( EBinOp
               ()
-              (EBinOp () (EVar () (Name () "a")) LessThan (EVar () (Name () "b")))
-              And
-              (EBinOp () (EVar () (Name () "c")) GreaterEqual (EVar () (Name () "d")))
+              ( EBinOp
+                  ()
+                  (EBinOp () (EVar () (Name () "a")) LessThan (EVar () (Name () "b")))
+                  And
+                  (EBinOp () (EVar () (Name () "c")) GreaterEqual (EVar () (Name () "d")))
+              )
+              Or
+              (EBinOp () (EVar () (Name () "e")) LessEqual (EVar () (Name () "f")))
           )
-          Or
-          (EBinOp () (EVar () (Name () "e")) LessEqual (EVar () (Name () "f")))
-
+          And
+          ( EBinOp
+              ()
+              (EVar () (Name () "g"))
+              Equals
+              (EVar () (Name () "h"))
+          )
     it "respects operator precedence for add/sub/mult/div" $
       stripAnns (fromRight $ parseExpression "a * b / c + d - e")
         `shouldBe` EBinOp -- i.e., (((a*b)/c)+d)-e


### PR DESCRIPTION
Previously, an expression like `0 == 1 && 2 == 3` would parse into the nonsensical `(0 == (1 && 2)) == 3`.

This PR gives `==` and `!=` higher precedence than `||` and `&&`. 

## Changes
- Give equality comparisons higher precedence than boolean operators
- Add test to ensure `==` has higher precedence than `&&`
