### PR TITLE
Check names

### DIFF
--- a/app/Command/Eval.hs
+++ b/app/Command/Eval.hs
@@ -4,7 +4,7 @@ import Command (Command (Eval), EvalOptions (..))
 import Error (HissError, showErr)
 import Interpreter.TreeWalker (HissValue, interp)
 import Options.Applicative (Parser, ParserInfo, argument, help, helper, info, metavar, progDesc, str, (<**>))
-import Semantic.Names (checkNames)
+import Semantic.Names (checkNames, reorderDecls)
 import Syntax (parseProgram)
 
 parser :: Parser Command
@@ -18,6 +18,7 @@ doEval' source = do
   ast <-
     parseProgram source -- parse/lex program
       >>= checkNames
+      >>= reorderDecls
 
   -- interpret the program
   interp ast

--- a/app/Command/Eval.hs
+++ b/app/Command/Eval.hs
@@ -4,6 +4,7 @@ import Command (Command (Eval), EvalOptions (..))
 import Error (HissError, showErr)
 import Interpreter.TreeWalker (HissValue, interp)
 import Options.Applicative (Parser, ParserInfo, argument, help, helper, info, metavar, progDesc, str, (<**>))
+import Semantic.Names (checkNames)
 import Syntax (parseProgram)
 
 parser :: Parser Command
@@ -16,6 +17,7 @@ doEval' :: String -> Either HissError HissValue
 doEval' source = do
   ast <-
     parseProgram source -- parse/lex program
+      >>= checkNames
 
   -- interpret the program
   interp ast

--- a/app/Command/Repl.hs
+++ b/app/Command/Repl.hs
@@ -6,6 +6,7 @@ import Data.Map.Strict (assocs)
 import Error (HissError, showErr)
 import Interpreter.TreeWalker (Environment, eval, globalEnv, insertDecl)
 import Options.Applicative (Parser, ParserInfo, argument, help, helper, info, metavar, progDesc, str, (<**>))
+import Semantic.Names (checkNames)
 import Syntax (parseDeclOrExp, parseProgram)
 import Syntax.AST (getIdent, stripAnns)
 import System.IO (hFlush, stdout)
@@ -17,7 +18,7 @@ replOptsParser :: ParserInfo Command
 replOptsParser = info (parser <**> helper) (progDesc "Load a Hiss program and start a REPL")
 
 loadProg :: String -> Either HissError Environment
-loadProg src = parseProgram src >>= globalEnv
+loadProg src = parseProgram src >>= checkNames >>= globalEnv
 
 printEnv :: Environment -> IO ()
 printEnv env = do

--- a/app/Command/Repl.hs
+++ b/app/Command/Repl.hs
@@ -6,7 +6,7 @@ import Data.Map.Strict (assocs)
 import Error (HissError, showErr)
 import Interpreter.TreeWalker (Environment, eval, globalEnv, insertDecl)
 import Options.Applicative (Parser, ParserInfo, argument, help, helper, info, metavar, progDesc, str, (<**>))
-import Semantic.Names (checkNames)
+import Semantic.Names (checkNames, reorderDecls)
 import Syntax (parseDeclOrExp, parseProgram)
 import Syntax.AST (getIdent, stripAnns)
 import System.IO (hFlush, stdout)
@@ -18,7 +18,7 @@ replOptsParser :: ParserInfo Command
 replOptsParser = info (parser <**> helper) (progDesc "Load a Hiss program and start a REPL")
 
 loadProg :: String -> Either HissError Environment
-loadProg src = parseProgram src >>= checkNames >>= globalEnv
+loadProg src = parseProgram src >>= checkNames >>= reorderDecls >>= globalEnv
 
 printEnv :: Environment -> IO ()
 printEnv env = do

--- a/src/Semantic/Names.hs
+++ b/src/Semantic/Names.hs
@@ -1,8 +1,14 @@
-module Semantic.Names (collectNames) where
+module Semantic.Names (collectNames, checkNames) where
 
+import Control.Monad (unless, when)
+import Control.Monad.Except (ExceptT, MonadError (throwError), runExceptT)
+import Control.Monad.State (MonadState (get, put), State, evalState, gets, modify)
 import Data.Set (Set)
-import Data.Set qualified as Set (empty, singleton, union)
-import Syntax.AST (Expr (..), Name (..))
+import Data.Set qualified as Set (empty, insert, member, singleton, union)
+import Error (HissError (SemanticError))
+import Syntax (getLineCol, start)
+import Syntax.AST (Annotated (getAnn), Binding (..), Decl (..), Expr (..), Name (..), Program, declGetName, getIdent, progDecls)
+import Syntax.Lexer (Range)
 
 -- | Collects Names referenced in an expression and all of its descendants.
 collectNames :: Expr a -> Set (Name a)
@@ -15,3 +21,131 @@ collectNames (EBinOp _ e1 _ e2) = collectNames e1 `Set.union` collectNames e2
 collectNames (ELetIn _ _ e1 e2) = collectNames e1 `Set.union` collectNames e2
 collectNames (EIf _ e1 e2 e3) = collectNames e1 `Set.union` collectNames e2 `Set.union` collectNames e3
 collectNames (EParen _ e1) = collectNames e1
+
+-- | Name-checks a program.
+-- Returns an error if a global is declared more than once, a binding shadows a global, or an undeclared name is used.
+-- On success, returns the program unchanged.
+checkNames :: Program Range -> Either HissError (Program Range)
+checkNames prog = do
+  -- initialize name check ctx
+  gs <- progGlobals prog
+  let ctx =
+        NameCheckCtx
+          { globals = gs,
+            declared = gs
+          }
+  -- actually run name check
+  evalState (runExceptT $ progCheckNames prog) ctx
+  -- return program unchanged
+  return prog
+
+-- | Collects the names of a program's globals, ensuring they are unique.
+progGlobals :: Program Range -> Either HissError (Set (Name Range))
+progGlobals = go . progDecls
+  where
+    go = foldl f (Right Set.empty)
+    f (Left err) _ = Left err -- propagate error
+    f (Right decld) decl
+      -- check if this name is already declared
+      -- if so, error
+      | name `Set.member` decld = Left $ SemanticError $ "Name error: Global '" <> getIdent name <> "' redeclared at line " <> show line <> ", column " <> show column
+      -- if not, insert it
+      | otherwise = Right (name `Set.insert` decld)
+      where
+        name = declGetName decl
+        (line, column) = getLineCol $ start $ getAnn name
+
+data NameCheckCtx = NameCheckCtx
+  { globals :: Set (Name Range),
+    declared :: Set (Name Range)
+  }
+
+type NameCheck = ExceptT HissError (State NameCheckCtx)
+
+-- | Throws if 'name' shadows a global in current context.
+throwIfShadowsGlobal :: Name Range -> NameCheck ()
+throwIfShadowsGlobal name = do
+  gs <- gets globals
+
+  when (name `Set.member` gs) $
+    throwError $
+      SemanticError $
+        "Name error: Global '" <> getIdent name <> "' shadowed by declaration at line " <> show line <> ", column " <> show col
+  where
+    (line, col) = getLineCol $ start $ getAnn name
+
+-- | Throws if 'name' is undeclared in current context.
+throwIfUndeclared :: Name Range -> NameCheck ()
+throwIfUndeclared name = do
+  decld <- gets declared
+
+  unless (name `Set.member` decld) $
+    throwError $
+      SemanticError $
+        "Name error: Use of undeclared name '" <> getIdent name <> "' at line " <> show line <> ", column " <> show col
+  where
+    (line, col) = getLineCol $ start $ getAnn name
+
+-- | Marks 'name' as declared in current context.
+declare :: Name Range -> NameCheck ()
+declare name = do
+  decld <- gets declared
+  let decld' = name `Set.insert` decld
+  modify $ \ctx -> ctx {declared = decld'}
+
+-- | Name-checks a program.
+progCheckNames :: Program Range -> NameCheck ()
+progCheckNames prog = do
+  mapM_ declCheckNames $ progDecls prog
+
+-- | Name-checks a declaration.
+declCheckNames :: Decl Range -> NameCheck ()
+declCheckNames (Decl _ (ValBinding _ _) body) = exprCheckNames body
+declCheckNames (Decl _ (FuncBinding _ _ args) body) = do
+  ctx <- get -- backup ctx
+
+  -- mark args as declared in body
+  mapM_ throwIfShadowsGlobal args
+  mapM_ declare args
+  exprCheckNames body
+
+  put ctx -- restore ctx
+
+exprCheckNames :: Expr Range -> NameCheck ()
+exprCheckNames (EInt _ _) = return ()
+exprCheckNames (EBool _ _) = return ()
+exprCheckNames (EVar _ name) = throwIfUndeclared name
+exprCheckNames (EFunApp _ fun args) = do
+  exprCheckNames fun
+  mapM_ exprCheckNames args
+exprCheckNames (EUnaryOp _ _ operand) = exprCheckNames operand
+exprCheckNames (EBinOp _ op1 _ op2) = do
+  exprCheckNames op1
+  exprCheckNames op2
+exprCheckNames (ELetIn _ binding valExp inExp) = case binding of
+  ValBinding _ name -> do
+    ctx <- get -- back up ctx
+    exprCheckNames valExp
+    throwIfShadowsGlobal name
+    declare name
+    exprCheckNames inExp
+    put ctx -- restore ctx
+  FuncBinding _ name args -> do
+    ctx <- get -- back up ctx
+
+    -- function name is declared in inExp
+    throwIfShadowsGlobal name
+    declare name
+    exprCheckNames inExp
+
+    -- function name and args are declared in valExp
+    mapM_ throwIfShadowsGlobal args
+    mapM_ declare args
+    exprCheckNames valExp
+
+    put ctx -- restore ctx
+exprCheckNames (EIf _ condExp thenExp elseExp) = do
+  exprCheckNames condExp
+  exprCheckNames thenExp
+  exprCheckNames elseExp
+exprCheckNames (EParen _ subexpr) = exprCheckNames subexpr

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -15,7 +15,7 @@ stop (Range _ p) = p
 
 -- | Gets the line and column of an AlexPosn.
 getLineCol :: AlexPosn -> (Int, Int)
-getLineCol (AlexPn l c _) = (l, c)
+getLineCol (AlexPn _ l c) = (l, c)
 
 -- Wraps Lexer.parseProgram and returns HissError in case of failure
 parseProgram :: String -> Either HissError (Program Range)

--- a/test/Semantic/NamesSpec.hs
+++ b/test/Semantic/NamesSpec.hs
@@ -1,9 +1,10 @@
 module Semantic.NamesSpec (spec) where
 
 import Data.Set qualified as Set (fromList)
-import Semantic.Names (collectNames)
-import Syntax (parseExpression)
-import Syntax.AST (Expr, Name (..))
+import Error
+import Semantic.Names (checkNames, collectNames)
+import Syntax (parseExpression, parseProgram)
+import Syntax.AST (Expr, Name (..), Program)
 import Syntax.Lexer (AlexPosn (..), Range (..))
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Util (fromRight)
@@ -14,6 +15,18 @@ exp1 = fromRight $ parseExpression "x + y - z"
 exp2 :: Expr Range
 exp2 = fromRight $ parseExpression "let f(x,y) = z in f(0)"
 
+prog1 :: Program Range
+prog1 = fromRight $ parseProgram "x = y + 1 \n y = 1"
+
+prog2 :: Program Range
+prog2 = fromRight $ parseProgram "inc(x) = x + 1 \n main = x"
+
+prog3 :: Program Range
+prog3 = fromRight $ parseProgram "f(x) = x \n f(x) = x + 1"
+
+prog4 :: Program Range
+prog4 = fromRight $ parseProgram "x = 1 \n x = 2"
+
 spec :: Spec
 spec = do
   describe "collectNames" $ do
@@ -21,3 +34,13 @@ spec = do
       collectNames exp1 `shouldBe` Set.fromList [Name (Range (AlexPn 0 1 1) (AlexPn 1 1 2)) "x", Name (Range (AlexPn 4 1 5) (AlexPn 5 1 6)) "y", Name (Range (AlexPn 8 1 9) (AlexPn 9 1 10)) "z"]
     it "does not collect function parameters" $
       collectNames exp2 `shouldBe` Set.fromList [Name (Range (AlexPn 17 1 18) (AlexPn 18 1 19)) "f", Name (Range (AlexPn 12 1 13) (AlexPn 13 1 14)) "z"]
+  describe "checkNames" $ do
+    it "hoists top-level declarations" $
+      -- i.e., you can use "y" in the definition of "x" even though "y" is declared after
+      checkNames prog1 `shouldBe` Right prog1
+    it "does not allow use of function arguments outside function" $
+      checkNames prog2 `shouldBe` Left (SemanticError "Name error: Use of undeclared name 'x' at line 2, column 9")
+    it "emits error on redeclaration of function" $
+      checkNames prog3 `shouldBe` Left (SemanticError "Name error: Global 'f' redeclared at line 2, column 2")
+    it "emits error on redeclaration of value" $
+      checkNames prog4 `shouldBe` Left (SemanticError "Name error: Global 'x' redeclared at line 2, column 2")

--- a/test/Semantic/NamesSpec.hs
+++ b/test/Semantic/NamesSpec.hs
@@ -2,9 +2,9 @@ module Semantic.NamesSpec (spec) where
 
 import Data.Set qualified as Set (fromList)
 import Error
-import Semantic.Names (checkNames, collectNames)
+import Semantic.Names (checkNames, collectNames, reorderDecls)
 import Syntax (parseExpression, parseProgram)
-import Syntax.AST (Expr, Name (..), Program)
+import Syntax.AST (Expr, Name (..), Program, declGetName, progDecls, stripAnns)
 import Syntax.Lexer (AlexPosn (..), Range (..))
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Util (fromRight)
@@ -27,6 +27,15 @@ prog3 = fromRight $ parseProgram "f(x) = x \n f(x) = x + 1"
 prog4 :: Program Range
 prog4 = fromRight $ parseProgram "x = 1 \n x = 2"
 
+prog5 :: Program Range -- simple cyclic program
+prog5 = fromRight $ parseProgram "a = b \n b = c \n c = a"
+
+prog6 :: Program Range -- cyclic program containing functions
+prog6 = fromRight $ parseProgram "a = f() \n f() = a"
+
+prog7 :: Program Range -- acyclic program with mutually recursive functions
+prog7 = fromRight $ parseProgram "f() = g() + a \n g() = f() + b \n a = 1 \n b = 1"
+
 spec :: Spec
 spec = do
   describe "collectNames" $ do
@@ -37,6 +46,8 @@ spec = do
   describe "checkNames" $ do
     it "hoists top-level declarations" $
       -- i.e., you can use "y" in the definition of "x" even though "y" is declared after
+
+      -- i.e., you can use "y" in the definition of "x" even though "y" is declared after
       checkNames prog1 `shouldBe` Right prog1
     it "does not allow use of function arguments outside function" $
       checkNames prog2 `shouldBe` Left (SemanticError "Name error: Use of undeclared name 'x' at line 2, column 9")
@@ -44,3 +55,16 @@ spec = do
       checkNames prog3 `shouldBe` Left (SemanticError "Name error: Global 'f' redeclared at line 2, column 2")
     it "emits error on redeclaration of value" $
       checkNames prog4 `shouldBe` Left (SemanticError "Name error: Global 'x' redeclared at line 2, column 2")
+  describe "reorderDecls" $ do
+    it "emits error on a simple value cycle" $
+      reorderDecls prog5 `shouldBe` Left (SemanticError "Definition of 'a' at line 1, column 1 is cyclic")
+    it "emits error on a value cycle through a function" $
+      reorderDecls prog6 `shouldBe` Left (SemanticError "Definition of 'a' at line 1, column 1 is cyclic")
+    it "correctly re-orders declarations of a program with mutually recursive functions" $
+      map (stripAnns . declGetName) <$> (progDecls <$> reorderDecls prog7)
+        `shouldBe` Right
+          [ Name () "b",
+            Name () "a",
+            Name () "f",
+            Name () "g"
+          ]


### PR DESCRIPTION
Adds two semantic passes, `checkNames` and `reorderDecls`.

`checkNames` walks the AST and ensures that:
- Globals have unique names.
- Local bindings do not shadow globals.
- Undeclared names are never used.

`reorderDecls` builds a dependency graph of program declarations to ensure that there are no cyclic definitions (e.g., `a = b, b = c, c = a`).
It also checks for value dependencies through functions (e.g., `a = f(), f() = a`), but it specifically ignores dependency cycles consisting of functions (e.g., `f() = g(), g() = f()`) since mutual recursion is allowed.
Finally, it returns a (semantically equivalent) program with the declarations reordered to support interpretation.
Specifically, in the new program, values are guaranteed to be declared (lexically) before they are used.

## Changes
- Implement `checkNames`
- Implement `reorderDecls`
- Add unit tests
